### PR TITLE
Remove extensibility feature from experimental features in bicepconfig.json

### DIFF
--- a/samples/bicepconfig.json
+++ b/samples/bicepconfig.json
@@ -1,6 +1,5 @@
 {
   "experimentalFeaturesEnabled": {
-    "extensibility": true,
     "localDeploy": true
   },
   "cloud": {


### PR DESCRIPTION
Removed the `extensibility `flag, as it’s no longer part of the experimental features.